### PR TITLE
Changes implemented into "Meal Cost"(Universal) to "Bill Amount" in a…

### DIFF
--- a/src/TipCalc/Components/SimpleView.razor
+++ b/src/TipCalc/Components/SimpleView.razor
@@ -1,5 +1,5 @@
 ﻿<label for="bill-amount">Bill Amount:</label>
-<input id="bill-amount" type="number" placeholder="bill-amount"
+<input id="bill-amount" type="number" placeholder="bill amount"
        value="@this.PercentCalculations.BillAmount"
        @oninput="@this.HandleBillAmountChanged" />
 

--- a/src/TipCalc/Components/SimpleView.razor
+++ b/src/TipCalc/Components/SimpleView.razor
@@ -1,7 +1,7 @@
-﻿<label for="meal-cost">Meal Cost:</label>
-<input id="meal-cost" type="number" placeholder="meal cost"
-       value="@this.PercentCalculations.MealAmount"
-       @oninput="@this.HandleMealAmountChanged" />
+﻿<label for="bill-amount">Bill Amount:</label>
+<input id="bill-amount" type="number" placeholder="bill-amount"
+       value="@this.PercentCalculations.BillAmount"
+       @oninput="@this.HandleBillAmountChanged" />
 
 @if (this.PercentCalculations is null)
 {

--- a/src/TipCalc/Components/SimpleView.razor.cs
+++ b/src/TipCalc/Components/SimpleView.razor.cs
@@ -21,11 +21,11 @@ namespace JK.TipCalc.Components
             };
         }
 
-        protected void HandleMealAmountChanged(ChangeEventArgs e)
+        protected void HandleBillAmountChanged(ChangeEventArgs e)
         {
             var candidate = e?.Value.ToString();
             var parsedValue = decimal.TryParse(candidate, out decimal value) ? value : 0;
-            this.PercentCalculations.MealAmount = parsedValue;
+            this.PercentCalculations.BillAmount = parsedValue;
             this.CustomTip.Amount = parsedValue;
         }
 

--- a/src/TipCalc/Models/TipCalculationList.cs
+++ b/src/TipCalc/Models/TipCalculationList.cs
@@ -6,12 +6,12 @@ namespace JK.TipCalc.Models
     public class TipCalculationList : IList<TipCalculation>
     {
         private List<TipCalculation> list;
-        private decimal mealAmount;
+        private decimal billAmount;
 
         public TipCalculationList()
         {
             this.list = new List<TipCalculation>();
-            this.mealAmount = 0;
+            this.billAmount = 0;
         }
 
         #region IList Implementation
@@ -38,12 +38,12 @@ namespace JK.TipCalc.Models
 
         #endregion
 
-        public decimal MealAmount 
+        public decimal BillAmount 
         {
-            get => this.mealAmount; 
+            get => this.billAmount; 
             set
             {
-                this.mealAmount = value;
+                this.billAmount = value;
                 foreach (var tipCalc in this.list)
                 {
                     tipCalc.Amount = value;


### PR DESCRIPTION
To explain the universal, all words matching Meal Cost, have all been switched to Bill Amount. This applies to instances of:

- SimpleView.razor
- SimpleView.razor.cs
- TipCalculationList.cs

These were tested before committing.